### PR TITLE
Renamed symbolic names for reosurces to adhere to naming conventions

### DIFF
--- a/deploy/.terraform.lock.hcl
+++ b/deploy/.terraform.lock.hcl
@@ -3,9 +3,10 @@
 
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.48.0"
-  constraints = "3.48.0"
+  constraints = "~> 3.48.0"
   hashes = [
     "h1:5sGcXKelc4o4MnPZfKKs9pd8w969TtlCV+0IZvW58Cs=",
+    "h1:MrojhMxADZXFiCAd4dtSfvC4/n0xiQGN95/XpUBaBsI=",
     "h1:a10lHsIgHJY+4l9RQaxA1iw8ZOUfGYnVlPvL25cH4HM=",
     "zh:01bd328009f2803ebc18ac27535e7d1548c735bb5bd02460e471acc835e5dd19",
     "zh:070b0bdd5ff27232eec7ef9128fc9bd17e6bdae503ddcc450c944449f3a8d216",
@@ -27,6 +28,7 @@ provider "registry.terraform.io/hashicorp/local" {
   hashes = [
     "h1:7RnIbO3CFakblTJs7o0mUiY44dc9xGYsLhSNFSNS1Ds=",
     "h1:R97FTYETo88sT2VHfMgkPU3lzCsZLunPftjSI5vfKe8=",
+    "h1:ZUEYUmm2t4vxwzxy1BvN1wL6SDWrDxfH7pxtzX8c6d0=",
     "zh:53604cd29cb92538668fe09565c739358dc53ca56f9f11312b9d7de81e48fab9",
     "zh:66a46e9c508716a1c98efbf793092f03d50049fa4a83cd6b2251e9a06aca2acf",
     "zh:70a6f6a852dd83768d0778ce9817d81d4b3f073fab8fa570bff92dcb0824f732",

--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -1,18 +1,21 @@
-// Resource group configuration
+data "local_file" "script" {
+  filename = "../src/List-PastAlerts.ps1"
+}
 
-resource "azurerm_resource_group" "rg-monitor-automation" {
+data "azurerm_subscription" "primary" {
+}
+
+resource "azurerm_resource_group" "rg" {
   name     = var.rg_name
   location = var.rg_location
 
   tags = local.tags
 }
 
-## Automation account configuration
-
-resource "azurerm_automation_account" "aa-monitor-automation" {
+resource "azurerm_automation_account" "account" {
   name                = var.aa_account_name
-  location            = azurerm_resource_group.rg-monitor-automation.location
-  resource_group_name = azurerm_resource_group.rg-monitor-automation.name
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
   sku_name            = var.aa_account_sku
 
   identity {
@@ -22,19 +25,12 @@ resource "azurerm_automation_account" "aa-monitor-automation" {
   tags = local.tags
 }
 
-data "local_file" "script" {
-  filename = "../src/List-PastAlerts.ps1"
-}
 
-data "azurerm_subscription" "primary" {
-}
-
-
-resource "azurerm_automation_runbook" "aa-runbook" {
+resource "azurerm_automation_runbook" "runbook" {
   name                    = "Get-AzureMonitorAlerts"
-  location                = azurerm_resource_group.rg-monitor-automation.location
-  resource_group_name     = azurerm_resource_group.rg-monitor-automation.name
-  automation_account_name = azurerm_automation_account.aa-monitor-automation.name
+  location                = azurerm_resource_group.rg.location
+  resource_group_name     = azurerm_resource_group.rg.name
+  automation_account_name = azurerm_automation_account.account.name
   log_verbose             = "true"
   log_progress            = "true"
   description             = "Run this script to get past Azure Monitor Alerts"
@@ -47,8 +43,8 @@ resource "azurerm_automation_runbook" "aa-runbook" {
 
 resource "azurerm_automation_schedule" "schedule" {
   name                    = "powershell-automation-schedule"
-  resource_group_name     = azurerm_resource_group.rg-monitor-automation.name
-  automation_account_name = azurerm_automation_account.aa-monitor-automation.name
+  resource_group_name     = azurerm_resource_group.rg.name
+  automation_account_name = azurerm_automation_account.account.name
   frequency               = "Month"
 
   monthly_occurrence {
@@ -61,61 +57,59 @@ resource "azurerm_automation_schedule" "schedule" {
 
 resource "azurerm_automation_job_schedule" "jobschedule" {
   schedule_name           = azurerm_automation_schedule.schedule.name
-  resource_group_name     = azurerm_resource_group.rg-monitor-automation.name
-  automation_account_name = azurerm_automation_account.aa-monitor-automation.name
-  runbook_name            = azurerm_automation_runbook.aa-runbook.name
+  resource_group_name     = azurerm_resource_group.rg.name
+  automation_account_name = azurerm_automation_account.account.name
+  runbook_name            = azurerm_automation_runbook.runbook.name
 }
 
-resource "azurerm_automation_variable_string" "secret-variable" {
+resource "azurerm_automation_variable_string" "secret" {
   name                    = "accountKey"
-  resource_group_name     = azurerm_resource_group.rg-monitor-automation.name
-  automation_account_name = azurerm_automation_account.aa-monitor-automation.name
-  value                   = azurerm_storage_account.stg-monitor.primary_access_key
+  resource_group_name     = azurerm_resource_group.rg.name
+  automation_account_name = azurerm_automation_account.account.name
+  value                   = azurerm_storage_account.stg.primary_access_key
   encrypted               = true
   description             = "Account key for access to Azure Storage Account"
 }
 
-resource "azurerm_automation_variable_string" "storageacc-variable" {
+resource "azurerm_automation_variable_string" "storage_name_var" {
   name                    = "storageAccountName"
-  resource_group_name     = azurerm_resource_group.rg-monitor-automation.name
-  automation_account_name = azurerm_automation_account.aa-monitor-automation.name
-  value                   = azurerm_storage_account.stg-monitor.name
+  resource_group_name     = azurerm_resource_group.rg.name
+  automation_account_name = azurerm_automation_account.account.name
+  value                   = azurerm_storage_account.stg.name
   encrypted               = false
   description             = "The name of the Storage Account"
 }
 
 resource "azurerm_role_assignment" "contributor" {
-  scope                = azurerm_resource_group.rg-monitor-automation.id
+  scope                = azurerm_resource_group.rg.id
   role_definition_name = "Contributor"
-  principal_id         = azurerm_automation_account.aa-monitor-automation.identity[0].principal_id
+  principal_id         = azurerm_automation_account.account.identity[0].principal_id
 }
 
-resource "azurerm_role_assignment" "monitor-reader" {
+resource "azurerm_role_assignment" "monitor_reader" {
   scope                = data.azurerm_subscription.primary.id
   role_definition_name = "Monitoring Reader"
-  principal_id         = azurerm_automation_account.aa-monitor-automation.identity[0].principal_id
+  principal_id         = azurerm_automation_account.account.identity[0].principal_id
 }
 
-## Storage account configuration
-
-resource "azurerm_storage_account" "stg-monitor" {
+resource "azurerm_storage_account" "stg" {
   name                     = var.stg_name
-  resource_group_name      = azurerm_resource_group.rg-monitor-automation.name
-  location                 = azurerm_resource_group.rg-monitor-automation.location
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = azurerm_resource_group.rg.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
 
   tags = local.tags
 }
 
-resource "azurerm_storage_share" "stg-share" {
+resource "azurerm_storage_share" "share" {
   name                 = var.stg_share_name
-  storage_account_name = azurerm_storage_account.stg-monitor.name
+  storage_account_name = azurerm_storage_account.stg.name
   quota                = var.stg_share_quota
 }
 
-resource "azurerm_storage_share_directory" "stg-dir" {
+resource "azurerm_storage_share_directory" "directory" {
   name                 = var.stg_directory_name
-  share_name           = azurerm_storage_share.stg-share.name
-  storage_account_name = azurerm_storage_account.stg-monitor.name
+  share_name           = azurerm_storage_share.share.name
+  storage_account_name = azurerm_storage_account.stg.name
 }

--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -98,6 +98,7 @@ resource "azurerm_storage_account" "stg" {
   location                 = azurerm_resource_group.rg.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+  min_tls_version          = "TLS1_2"
 
   tags = local.tags
 }

--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -1,21 +1,20 @@
-data "local_file" "script" {
+data "local_file" "list_past_alerts_script" {
   filename = "../src/List-PastAlerts.ps1"
 }
 
-data "azurerm_subscription" "primary" {
-}
+data "azurerm_subscription" "primary" {}
 
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "this" {
   name     = var.rg_name
   location = var.rg_location
 
   tags = local.tags
 }
 
-resource "azurerm_automation_account" "account" {
+resource "azurerm_automation_account" "this" {
   name                = var.aa_account_name
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
   sku_name            = var.aa_account_sku
 
   identity {
@@ -26,25 +25,25 @@ resource "azurerm_automation_account" "account" {
 }
 
 
-resource "azurerm_automation_runbook" "runbook" {
+resource "azurerm_automation_runbook" "script" {
   name                    = "Get-AzureMonitorAlerts"
-  location                = azurerm_resource_group.rg.location
-  resource_group_name     = azurerm_resource_group.rg.name
-  automation_account_name = azurerm_automation_account.account.name
+  location                = azurerm_resource_group.this.location
+  resource_group_name     = azurerm_resource_group.this.name
+  automation_account_name = azurerm_automation_account.this.name
   log_verbose             = "true"
   log_progress            = "true"
   description             = "Run this script to get past Azure Monitor Alerts"
   runbook_type            = "PowerShell"
 
-  content = data.local_file.script.content
+  content = data.local_file.list_past_alerts_script.content
 
   tags = local.tags
 }
 
 resource "azurerm_automation_schedule" "schedule" {
   name                    = "powershell-automation-schedule"
-  resource_group_name     = azurerm_resource_group.rg.name
-  automation_account_name = azurerm_automation_account.account.name
+  resource_group_name     = azurerm_resource_group.this.name
+  automation_account_name = azurerm_automation_account.this.name
   frequency               = "Month"
 
   monthly_occurrence {
@@ -57,45 +56,45 @@ resource "azurerm_automation_schedule" "schedule" {
 
 resource "azurerm_automation_job_schedule" "jobschedule" {
   schedule_name           = azurerm_automation_schedule.schedule.name
-  resource_group_name     = azurerm_resource_group.rg.name
-  automation_account_name = azurerm_automation_account.account.name
-  runbook_name            = azurerm_automation_runbook.runbook.name
+  resource_group_name     = azurerm_resource_group.this.name
+  automation_account_name = azurerm_automation_account.this.name
+  runbook_name            = azurerm_automation_runbook.script.name
 }
 
 resource "azurerm_automation_variable_string" "secret" {
   name                    = "accountKey"
-  resource_group_name     = azurerm_resource_group.rg.name
-  automation_account_name = azurerm_automation_account.account.name
-  value                   = azurerm_storage_account.stg.primary_access_key
+  resource_group_name     = azurerm_resource_group.this.name
+  automation_account_name = azurerm_automation_account.this.name
+  value                   = azurerm_storage_account.this.primary_access_key
   encrypted               = true
   description             = "Account key for access to Azure Storage Account"
 }
 
 resource "azurerm_automation_variable_string" "storage_name_var" {
   name                    = "storageAccountName"
-  resource_group_name     = azurerm_resource_group.rg.name
-  automation_account_name = azurerm_automation_account.account.name
-  value                   = azurerm_storage_account.stg.name
+  resource_group_name     = azurerm_resource_group.this.name
+  automation_account_name = azurerm_automation_account.this.name
+  value                   = azurerm_storage_account.this.name
   encrypted               = false
   description             = "The name of the Storage Account"
 }
 
 resource "azurerm_role_assignment" "contributor" {
-  scope                = azurerm_resource_group.rg.id
+  scope                = azurerm_resource_group.this.id
   role_definition_name = "Contributor"
-  principal_id         = azurerm_automation_account.account.identity[0].principal_id
+  principal_id         = azurerm_automation_account.this.identity[0].principal_id
 }
 
 resource "azurerm_role_assignment" "monitor_reader" {
   scope                = data.azurerm_subscription.primary.id
   role_definition_name = "Monitoring Reader"
-  principal_id         = azurerm_automation_account.account.identity[0].principal_id
+  principal_id         = azurerm_automation_account.this.identity[0].principal_id
 }
 
-resource "azurerm_storage_account" "stg" {
+resource "azurerm_storage_account" "this" {
   name                     = var.stg_name
-  resource_group_name      = azurerm_resource_group.rg.name
-  location                 = azurerm_resource_group.rg.location
+  resource_group_name      = azurerm_resource_group.this.name
+  location                 = azurerm_resource_group.this.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
   min_tls_version          = "TLS1_2"
@@ -105,12 +104,12 @@ resource "azurerm_storage_account" "stg" {
 
 resource "azurerm_storage_share" "share" {
   name                 = var.stg_share_name
-  storage_account_name = azurerm_storage_account.stg.name
+  storage_account_name = azurerm_storage_account.this.name
   quota                = var.stg_share_quota
 }
 
 resource "azurerm_storage_share_directory" "directory" {
   name                 = var.stg_directory_name
   share_name           = azurerm_storage_share.share.name
-  storage_account_name = azurerm_storage_account.stg.name
+  storage_account_name = azurerm_storage_account.this.name
 }

--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -25,7 +25,7 @@ resource "azurerm_automation_account" "this" {
 }
 
 
-resource "azurerm_automation_runbook" "script" {
+resource "azurerm_automation_runbook" "this" {
   name                    = "Get-AzureMonitorAlerts"
   location                = azurerm_resource_group.this.location
   resource_group_name     = azurerm_resource_group.this.name
@@ -40,7 +40,7 @@ resource "azurerm_automation_runbook" "script" {
   tags = local.tags
 }
 
-resource "azurerm_automation_schedule" "schedule" {
+resource "azurerm_automation_schedule" "this" {
   name                    = "powershell-automation-schedule"
   resource_group_name     = azurerm_resource_group.this.name
   automation_account_name = azurerm_automation_account.this.name
@@ -54,11 +54,11 @@ resource "azurerm_automation_schedule" "schedule" {
   description = "Occurs once a month"
 }
 
-resource "azurerm_automation_job_schedule" "jobschedule" {
-  schedule_name           = azurerm_automation_schedule.schedule.name
+resource "azurerm_automation_job_schedule" "this" {
+  schedule_name           = azurerm_automation_schedule.this.name
   resource_group_name     = azurerm_resource_group.this.name
   automation_account_name = azurerm_automation_account.this.name
-  runbook_name            = azurerm_automation_runbook.script.name
+  runbook_name            = azurerm_automation_runbook.this.name
 }
 
 resource "azurerm_automation_variable_string" "secret" {
@@ -102,14 +102,14 @@ resource "azurerm_storage_account" "this" {
   tags = local.tags
 }
 
-resource "azurerm_storage_share" "share" {
+resource "azurerm_storage_share" "this" {
   name                 = var.stg_share_name
   storage_account_name = azurerm_storage_account.this.name
   quota                = var.stg_share_quota
 }
 
-resource "azurerm_storage_share_directory" "directory" {
+resource "azurerm_storage_share_directory" "this" {
   name                 = var.stg_directory_name
-  share_name           = azurerm_storage_share.share.name
+  share_name           = azurerm_storage_share.this.name
   storage_account_name = azurerm_storage_account.this.name
 }

--- a/deploy/outputs.tf
+++ b/deploy/outputs.tf
@@ -1,9 +1,9 @@
 output "automation_account_name" {
   description = "The name of the Automation Account"
-  value       = azurerm_automation_account.account.name
+  value       = azurerm_automation_account.this.name
 }
 
 output "storage_account_name" {
   description = "The name of the Storage Account"
-  value       = azurerm_storage_account.stg.name
+  value       = azurerm_storage_account.this.name
 }

--- a/deploy/outputs.tf
+++ b/deploy/outputs.tf
@@ -1,0 +1,9 @@
+output "automation_account_name" {
+  description = "The name of the Automation Account"
+  value       = azurerm_automation_account.account.name
+}
+
+output "storage_account_name" {
+  description = "The name of the Storage Account"
+  value       = azurerm_storage_account.stg.name
+}

--- a/deploy/terraform.tfvars
+++ b/deploy/terraform.tfvars
@@ -1,17 +1,20 @@
-// Resource group variables
-rg_name     = "rg-monitor-automation-001"
+rg_name = "rg-monitor-automation-001"
+
 rg_location = "West Europe"
 
-// Automation account variables
 aa_account_name = "aa-monitorautomation-001"
-aa_account_sku  = "Basic"
+
+aa_account_sku = "Basic"
+
+stg_name = "stgazuremonitoralert001"
+
+stg_share_name = "share01"
+
+stg_share_quota = 5
+
+stg_directory_name = "directory01"
+
 runbook_schedule = {
   day        = "Monday"
   occurrence = 1
 }
-
-## Storage account configuration
-stg_name           = "stgazuremonitoralert001"
-stg_share_name     = "share01"
-stg_share_quota    = 5
-stg_directory_name = "directory01"

--- a/deploy/variables.tf
+++ b/deploy/variables.tf
@@ -59,4 +59,3 @@ variable "stg_directory_name" {
   type        = string
   default     = "directory01"
 }
-

--- a/deploy/variables.tf
+++ b/deploy/variables.tf
@@ -8,9 +8,9 @@ variable "rg_name" {
 variable "rg_location" {
   description = "The location of the resource group"
   type        = string
+  default     = "West Europe"
 }
 
-// Automation account variables
 variable "aa_account_name" {
   description = "The name of the Automation Account"
   type        = string
@@ -35,7 +35,6 @@ variable "runbook_schedule" {
   }
 }
 
-// Storage account variables
 variable "stg_name" {
   description = "The name of the Storage Account"
   type        = string


### PR DESCRIPTION
- Renamed symbolic names to be singular or contain underscore
- Added `outputs.tf`
- Fixed spacing
- Locked in TLS1_2 for storage account from tfsec recommendation